### PR TITLE
Fix bug with expect scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -216,3 +216,8 @@ pip-log.txt
 .mr.developer.cfg
 
 .idea
+
+
+# From kateproject
+.kateproject
+.kateproject.d

--- a/conf/first_launch.exp
+++ b/conf/first_launch.exp
@@ -1,10 +1,11 @@
 #!/usr/bin/expect
 set timeout 10
 
-set admin_email [lindex $argv 0]
-set admin_password [lindex $argv 1]
+set seafile_dir [lindex $argv 0]
+set admin_email [lindex $argv 1]
+set admin_password [lindex $argv 2]
 
-spawn /var/www/seafile/seafile-server-latest/seahub.sh start-fastcgi
+spawn $seafile_dir/seahub.sh start-fastcgi
 
 expect "for the admin account?"
 send "$admin_email\r";

--- a/conf/install.exp
+++ b/conf/install.exp
@@ -1,13 +1,14 @@
 #!/usr/bin/expect
 set timeout 10
 
-set server_name [lindex $argv 0]
-set domain [lindex $argv 1]
-set seafile_data [lindex $argv 2]
-set fileserver_port [lindex $argv 3]
-set db_pwd [lindex $argv 4]
+set seafile_dir [lindex $argv 0]
+set server_name [lindex $argv 1]
+set domain [lindex $argv 2]
+set seafile_data [lindex $argv 3]
+set fileserver_port [lindex $argv 4]
+set db_pwd [lindex $argv 5]
 
-spawn /var/www/seafile/seafile-server-5.0.3/setup-seafile-mysql.sh
+spawn $seafile_dir/setup-seafile-mysql.sh
 
 expect "Press ENTER to continue"
 send "\r";

--- a/conf/upgrade_4.1.1.exp
+++ b/conf/upgrade_4.1.1.exp
@@ -1,9 +1,10 @@
 #!/usr/bin/expect
 set timeout 5
 
-set mysql_password [lindex $argv 0]
+set seafile_dir [lindex $argv 0]
+set mysql_password [lindex $argv 1]
 
-spawn /var/www/seafile/seafile-server-4.3.2/upgrade/upgrade_4.0_4.1.sh
+spawn $seafile_dir/upgrade/upgrade_4.0_4.1.sh
 
 expect "to contiune"
 send "\r";

--- a/conf/upgrade_4.2.1.exp
+++ b/conf/upgrade_4.2.1.exp
@@ -1,9 +1,10 @@
 #!/usr/bin/expect
 set timeout 5
 
-set mysql_password [lindex $argv 0]
+set seafile_dir [lindex $argv 0]
+set mysql_password [lindex $argv 1]
 
-spawn /var/www/seafile/seafile-server-4.3.2/upgrade/upgrade_4.1_4.2.sh
+spawn $seafile_dir/upgrade/upgrade_4.1_4.2.sh
 
 expect "to contiune"
 send "\r";

--- a/conf/upgrade_4.3.2.exp
+++ b/conf/upgrade_4.3.2.exp
@@ -1,9 +1,10 @@
 #!/usr/bin/expect
 set timeout 5
 
-set mysql_password [lindex $argv 0]
+set seafile_dir [lindex $argv 0]
+set mysql_password [lindex $argv 1]
 
-spawn /var/www/seafile/seafile-server-4.3.2/upgrade/upgrade_4.2_4.3.sh
+spawn $seafile_dir/upgrade/upgrade_4.2_4.3.sh
 
 expect "to contiune"
 send "\r";

--- a/conf/upgrade_4.4.3.exp
+++ b/conf/upgrade_4.4.3.exp
@@ -1,9 +1,10 @@
 #!/usr/bin/expect
 set timeout 5
 
-set mysql_password [lindex $argv 0]
+set seafile_dir [lindex $argv 0]
+set mysql_password [lindex $argv 1]
 
-spawn /var/www/seafile/seafile-server-4.4.3/upgrade/upgrade_4.3_4.4.sh
+spawn $seafile_dir/upgrade/upgrade_4.3_4.4.sh
 
 expect "to contiune"
 send "\r";

--- a/conf/upgrade_5.0.3.exp
+++ b/conf/upgrade_5.0.3.exp
@@ -1,9 +1,10 @@
 #!/usr/bin/expect
 set timeout 5
 
-set mysql_password [lindex $argv 0]
+set seafile_dir [lindex $argv 0]
+set mysql_password [lindex $argv 1]
 
-spawn /var/www/seafile/seafile-server-5.0.3/upgrade/upgrade_4.4_5.0.sh
+spawn $seafile_dir/upgrade/upgrade_4.4_5.0.sh
 
 expect "to contiune"
 send "\r";

--- a/scripts/install
+++ b/scripts/install
@@ -76,7 +76,7 @@ sudo yunohost app setting seafile db_pwd -v $db_pwd
 # Run install script
 sudo chmod +x ../conf/install.exp
 sudo chmod +x $final_path/seafile-server-$seafile_version/setup-seafile-mysql.sh
-sudo ../conf/install.exp $server_name $domain $seafile_data $fileserver_port $db_pwd
+sudo ../conf/install.exp $final_path/seafile-server-$seafile_version $server_name $domain $seafile_data $fileserver_port $db_pwd
 
 # Update seafile config
 sudo sed -i "s@http://@https://@g" $final_path/conf/ccnet.conf
@@ -132,7 +132,7 @@ sudo chown -R www-data:www-data $seafile_data
 
 # Start seafile, seahub and populate admin account
 sudo su - www-data -s /bin/bash -c "/var/www/seafile/seafile-server-$seafile_version/seafile.sh start"
-sudo su - www-data -s /bin/bash -c "$final_path/first_launch.exp $admin_email $admin_password"
+sudo su - www-data -s /bin/bash -c "$final_path/first_launch.exp $final_path/seafile-server-$seafile_version $admin_email $admin_password"
 
 # Add sso config to unprotect domain.tld/seafhttp + domain.tld/seafdav do in /etc/ssowat/conf.json.persistent
 sudo cp ../conf/add_sso_conf.py $final_path

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -34,22 +34,27 @@ sudo chmod +x $final_path/seafile-server-$seafile_version/upgrade/upgrade_4.4_5.
 case $installed_version in
 "4.0."* )
 	# Update seafile by script
-	sudo ../conf/upgrade_4.1.1.exp $root_pwd
-	sudo ../conf/upgrade_4.2.1.exp $root_pwd
-	sudo ../conf/upgrade_4.3.2.exp $root_pwd
+	sudo ../conf/upgrade_4.1.1.exp $final_path/seafile-server-$seafile_version $root_pwd
+	sudo ../conf/upgrade_4.2.1.exp $final_path/seafile-server-$seafile_version $root_pwd
+	sudo ../conf/upgrade_4.3.2.exp $final_path/seafile-server-$seafile_version $root_pwd
+	sudo ../conf/upgrade_4.4.3.exp $final_path/seafile-server-$seafile_version $root_pwd
+	sudo ../conf/upgrade_5.0.3.exp $final_path/seafile-server-$seafile_version $root_pwd
 ;;
 "4.1."* )
 	# Update seafile by script
-	sudo ../conf/upgrade_4.2.1.exp $root_pwd
-	sudo ../conf/upgrade_4.3.2.exp $root_pwd
+	sudo ../conf/upgrade_4.2.1.exp $final_path/seafile-server-$seafile_version $root_pwd
+	sudo ../conf/upgrade_4.3.2.exp $final_path/seafile-server-$seafile_version $root_pwd
+	sudo ../conf/upgrade_4.4.3.exp $final_path/seafile-server-$seafile_version $root_pwd
+	sudo ../conf/upgrade_5.0.3.exp $final_path/seafile-server-$seafile_version $root_pwd
 ;;
 "4.3."* )
 	# Update seafile by script
-	sudo ../conf/upgrade_4.4.3.exp $root_pwd
+	sudo ../conf/upgrade_4.4.3.exp $final_path/seafile-server-$seafile_version $root_pwd
+	sudo ../conf/upgrade_5.0.3.exp $final_path/seafile-server-$seafile_version $root_pwd
 ;;
 "4.4."* )
 	# Update seafile by script
-	sudo ../conf/upgrade_5.0.3.exp $root_pwd
+	sudo ../conf/upgrade_5.0.3.exp $final_path/seafile-server-$seafile_version $root_pwd
 ;;
 esac
 


### PR DESCRIPTION
When we use the expect script we have to use the script in the directory of the last version of seafile. I use a variable for doing upgrade easier than with a fixed path.