### PR TITLE
#164: Avoid to have collision on user ID in docker image

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -63,9 +63,13 @@ run_seafile_cmd() {
 }
 
 update_pwd_group_shadow_in_docker() {
+    # We remove all entries to just keep root + seafile users in the docker because we need to avoid any collision with other user ID which already in the
+    echo 'root:x:0:0:root:/root:/bin/bash' > "$1/etc/passwd"
     grep "^$app:x" /etc/passwd | sed "s|$install_dir|/opt/seafile|" >> "$1/etc/passwd"
+
+    echo 'root:x:0:' > "$1/etc/group"
     grep "^$app:x" /etc/group >> "$1/etc/group"
-    grep "^$app:x" /etc/group- >> "$1/etc/group-"
+
     grep "^$app:"  /etc/shadow >> "$1/etc/shadow"
 }
 


### PR DESCRIPTION
## Problem

- #164

## Solution

- Fix collision on user ID in docker image

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
