### PR TITLE
Redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Open source cloud storage
 
 [![🌐 Official app website](https://img.shields.io/badge/Official_app_website-darkgreen?style=for-the-badge)](https://www.seafile.com)
 [![App Demo](https://img.shields.io/badge/App_Demo-blue?style=for-the-badge)](https://demo.seafile.com)
-[![Version: 13.0.20~ynh1](https://img.shields.io/badge/Version-13.0.20~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/seafile/)
+[![Version: 13.0.20~ynh2](https://img.shields.io/badge/Version-13.0.20~ynh2-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/seafile/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/seafile"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/conf/seafile.conf
+++ b/conf/seafile.conf
@@ -19,6 +19,3 @@ user = __DB_USER__
 password = __DB_PWD__
 db_name = __DB_NAME__
 connection_charset = utf8
-
-[memcached]
-memcached_options = --SERVER=127.0.0.1 --POOL-MIN=10 --POOL-MAX=100

--- a/conf/seafile.conf
+++ b/conf/seafile.conf
@@ -22,10 +22,3 @@ connection_charset = utf8
 
 [memcached]
 memcached_options = --SERVER=127.0.0.1 --POOL-MIN=10 --POOL-MAX=100
-
-[notification]
-enabled = true
-host = 127.0.0.1
-port = __PORT_NOTIFICATIONSERVER__
-log_level = info
-jwt_private_key = __JWT_PRIVATE__

--- a/conf/seafile_env.j2
+++ b/conf/seafile_env.j2
@@ -5,6 +5,10 @@ SITE_ROOT={{ path2 }}
 SEAFILE_SERVER_PROTOCOL=https
 SEAFILE_SERVER_HOSTNAME={{ domain }}
 
+# Seafile 13's fileserver reads notification support from env, not seafile.conf.
+ENABLE_NOTIFICATION_SERVER=true
+INNER_NOTIFICATION_SERVER_URL=http://127.0.0.1:{{ port_notificationserver }}
+
 # Database
 SEAFILE_MYSQL_DB_HOST=127.0.0.1
 SEAFILE_MYSQL_DB_PORT=3306

--- a/conf/seafile_env.j2
+++ b/conf/seafile_env.j2
@@ -21,3 +21,9 @@ SEAFILE_MYSQL_DB_SEAHUB_DB_NAME=seahubdb
 # Seadoc
 ENABLE_SEADOC=true
 SEADOC_SERVER_URL=https://{{ domain }}{{ path2 }}sdoc
+
+# Redis config
+CACHE_PROVIDER=redis
+REDIS_HOST=127.0.0.1
+REDIS_PORT=6379
+REDIS_DB={{ redis_db }}

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "Seafile"
 description.en = "Open source cloud storage"
 description.fr = "Stockage cloud open source"
 
-version = "13.0.20~ynh1"
+version = "13.0.20~ynh2"
 
 maintainers = ["Josué Tille"]
 


### PR DESCRIPTION
## Problem

- We still use memcached config for fileserver and I'm not sure that it's supported any more.

## Solution

- Redo the config with redis.
- Note this require https://github.com/haiwen/seafile-server/pull/805 to have this fix working as expected.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
